### PR TITLE
Fix argument handling in SetupTaskHelper.

### DIFF
--- a/lib/hidapi/setup_task_helper.rb
+++ b/lib/hidapi/setup_task_helper.rb
@@ -8,8 +8,8 @@ module HIDAPI
     attr_reader :vendor_id, :product_id, :simple_name, :interface
 
     def initialize(vendor_id, product_id, simple_name, interface)
-      @vendor_id = vendor_id.to_s.strip.to_i(16)
-      @product_id = product_id.to_s.strip.to_i(16)
+      @vendor_id = interpret_id(vendor_id)
+      @product_id = interpret_id(product_id)
       @simple_name = simple_name.to_s.strip.gsub(' ', '_').gsub(/[^A-Za-z0-9_\-]/, '')
       @interface = interface.to_s.strip.to_i
       @temp_dir = Dir.mktmpdir('hidapi_setup')
@@ -229,6 +229,11 @@ LABEL="hidapi_rules_end"
       true
     end
 
+    private
+
+    def interpret_id(id)
+      id.is_a?(Integer) ? id : id.to_s.strip.to_i(16)
+    end
   end
 end
 


### PR DESCRIPTION
So when I follow the directions for creating a `udev` rule...

```ruby
HIDAPI::SetupTaskHelper.new(
  0xd209,
  0x0420,
  "foo",
  0
).run
```

... I get an entry in my `udev` rules like this:

```
ATTR{idVendor}=="53769", ATTR{idProduct}=="1056", MODE="0666", SYMLINK+="hidapi/foo@%k"
```

This doesn't work until I manually edit it to:

```
ATTR{idVendor}=="d209", ATTR{idProduct}=="0420", MODE="0666", SYMLINK+="hidapi/foo@%k"
```

I think `SetupTaskHelper` wants to produce hex output, but in `#initialize` it gets transformed like this:

```ruby
(0xd209).to_s.strip.to_i(16) # -> 341865 (should be 53769?)
```

… and then when written to the rules file, it gets transformed to this:

```ruby
(341865).to_s(16).rjust(4, '0') # -> "53769" (should be "d209")
```

It seems like the intent in `#initialize` was to be flexible enough to accept either (e.g.) `0xd209` or `"d209"`, so that's what I did with this PR. Integers will get left alone in `#initialize` because they're already base-ten integers; everything else gets string-coerced and whatnot. This seems to do the right thing for `vendor_id` and `product_id` whether they're integers or strings or symbols.