### PR TITLE
Ruby 2.4 Fixnum -> Integer

### DIFF
--- a/lib/hidapi/numeric_extensions.rb
+++ b/lib/hidapi/numeric_extensions.rb
@@ -1,5 +1,5 @@
 
-Fixnum.class_eval do
+Integer.class_eval do
 
   ##
   # Converts an integer into a hex string with the specified length.


### PR DESCRIPTION
In Ruby 2.4, Bignum and Fixnum are deprecated in favor of Integer, which is the superclass of both. This just changes the one hex conversion helper to be on Integer, suppressing a warning on launch.