### PR TITLE
Switch reads to use semaphors to minimize background CPU usage

### DIFF
--- a/lib/hidapi/device.rb
+++ b/lib/hidapi/device.rb
@@ -342,7 +342,11 @@ module HIDAPI
             end
 
             # Sleep until there is something ready for us
-            semaphore.wait(mutex)
+            begin
+              semaphore.wait(mutex)
+            rescue Exception
+              return nil
+            end
           end
         end
 
@@ -361,7 +365,11 @@ module HIDAPI
             end
 
             # Sleep until there is something ready for us or we time out
-            semaphore.wait(mutex, milliseconds * 0.001)
+            begin
+              semaphore.wait(mutex, milliseconds * 0.001)
+            rescue Exception
+              return nil
+            end
 
             # If we woke up and there are no pending reports, we timed out
             return ''                   if input_reports.count.zero?


### PR DESCRIPTION
Noticing that the act of blocking read from a USB HID device was consuming 15-30% of a CPU, switched code from doing a timed/poll to using a semaphore/conditionalVariable which reduced background CPU usage to effectively nil.

Technically, it should respond to an events faster, but the difference is likely nearly imperceptible.  