### PR TITLE
Updating dependencies and bumping version to 0.1.10

### DIFF
--- a/hidapi.gemspec
+++ b/hidapi.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version                = '>= 2.2.0'
-  spec.add_dependency             'libusb',   '~>0.5.1'
-  spec.add_dependency             'i18n'
+  spec.add_dependency             'libusb',   '~> 0.6'
+  spec.add_dependency             'i18n',     '~> 1.8'
 
-  spec.add_development_dependency 'bundler',  '~>1.12'
-  spec.add_development_dependency 'rake',     '~> 10.0'
+  spec.add_development_dependency 'bundler',  '~> 2.3'
+  spec.add_development_dependency 'rake',     '~> 13.0'
 end

--- a/lib/hidapi/version.rb
+++ b/lib/hidapi/version.rb
@@ -1,3 +1,3 @@
 module HIDAPI
-  VERSION = '0.1.9'
+  VERSION = '0.1.10'
 end


### PR DESCRIPTION
The following dependencies have been updated:

- `libusb` to `~> 0.6`
- `i18n` to `~> 1.8`
- `bundler` to `~> 2.3`
- `rake` to `~> 13.0`

Gem version was bumped to `0.1.10`.
